### PR TITLE
Add USB flashing helper script

### DIFF
--- a/README.md
+++ b/README.md
@@ -56,6 +56,23 @@ Collection of preloaded USB toolkit images for various cybersecurity, developmen
 git push origin main
 ```
 
+## Flashing Images to USB
+
+After building an image you can write it to a USB drive with the helper script:
+
+```bash
+sudo ./flash_usb.sh <image_file> <device>
+```
+
+Example:
+
+```bash
+sudo ./flash_usb.sh pentest-kit.img /dev/sdX
+```
+
+Replace `/dev/sdX` with your target device (e.g., `/dev/sdb`). The script will
+prompt for confirmation before overwriting the device.
+
 ## Project Structure
 
 ```

--- a/flash_usb.sh
+++ b/flash_usb.sh
@@ -1,0 +1,54 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+usage() {
+    echo "Usage: $0 <image_path> <target_device>"
+    exit 1
+}
+
+# Require root
+if [[ $EUID -ne 0 ]]; then
+    echo "This script must be run as root." >&2
+    exit 1
+fi
+
+if [[ $# -ne 2 ]]; then
+    usage
+fi
+
+IMG="$1"
+DEV="$2"
+
+if [[ ! -f "$IMG" ]]; then
+    echo "Image file not found: $IMG" >&2
+    exit 1
+fi
+
+if [[ ! -b "$DEV" ]]; then
+    echo "Target device not found or not a block device: $DEV" >&2
+    exit 1
+fi
+
+read -r -p "All data on $DEV will be overwritten. Continue? [y/N] " ans
+case $ans in
+    y|Y) ;;
+    *) echo "Aborted."; exit 1;;
+esac
+
+# Attempt to unmount any mounted partitions
+if mount | grep -q "$DEV"; then
+    echo "Unmounting $DEV partitions..."
+    umount ${DEV}?* || true
+fi
+
+sync
+
+echo "Flashing $IMG to $DEV..."
+if [[ $(uname) == "Darwin" ]]; then
+    dd if="$IMG" of="$DEV" bs=1m status=progress conv=sync
+else
+    dd if="$IMG" of="$DEV" bs=4M status=progress conv=fsync
+fi
+
+sync
+echo "Done."


### PR DESCRIPTION
## Summary
- add `flash_usb.sh` to write images to USB devices
- document flashing workflow in README

## Testing
- `bash -n flash_usb.sh`


------
https://chatgpt.com/codex/tasks/task_e_687efa2f545483309ed842ed60f10dd8