### PR TITLE
Fix overlay path in build.sh

### DIFF
--- a/build.sh
+++ b/build.sh
@@ -2,13 +2,21 @@
 set -e
 
 # Input validation
-if [ "$#" -ne 2 ]; then
-    echo "Usage: $0 <iso_file> <output_img>"
+if [ "$#" -lt 2 ] || [ "$#" -gt 3 ]; then
+    echo "Usage: $0 <iso_file> <output_img> [overlay_dir]"
     exit 1
 fi
 
 ISO="$1"
 USB_IMG="$2"
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+DEFAULT_OVERLAY="$SCRIPT_DIR/core/overlay"
+OVERLAY_DIR="${3:-${OVERLAY_DIR:-$DEFAULT_OVERLAY}}"
+
+if [ ! -d "$OVERLAY_DIR" ]; then
+    echo "Overlay directory '$OVERLAY_DIR' not found" >&2
+    exit 1
+fi
 
 # Create temporary work directory
 work=$(mktemp -d)
@@ -17,8 +25,8 @@ trap 'rm -rf "$work"' EXIT
 echo "Extracting ISO..."
 7z x "$ISO" -o"$work/extract"
 
-echo "Applying overlay..."
-cp -r overlay/* "$work/extract/"
+echo "Applying overlay from $OVERLAY_DIR..."
+cp -r "$OVERLAY_DIR"/* "$work/extract/"
 
 echo "Creating bootable image..."
 mkisofs -o "$USB_IMG" \


### PR DESCRIPTION
## Summary
- fix build.sh to look for the overlay in `core/overlay`
- allow custom overlay directories via arg or `OVERLAY_DIR` env var
- ensure script is executable and works from repo root

## Testing
- `mkisofs -o base.iso -b isolinux/isolinux.bin -c isolinux/boot.cat -no-emul-boot -boot-load-size 4 -boot-info-table -allow-lowercase -l testdir`
- `./build.sh base.iso output.iso`

------
https://chatgpt.com/codex/tasks/task_e_687efaa5e8d48330b176300f96ea4173