### PR TITLE
Add base_iso directory setup

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -47,6 +47,10 @@ jobs:
         sudo apt-get update
         sudo apt-get install -y p7zip-full genisoimage
 
+    - name: Prepare base_iso directory
+      run: |
+        mkdir -p base_iso
+
     - name: Download base ISO
       run: |
         wget -O base_iso/${{ matrix.toolkit.base_iso }} ${{ matrix.toolkit.iso_url }}

--- a/README.md
+++ b/README.md
@@ -48,6 +48,10 @@ Collection of preloaded USB toolkit images for various cybersecurity, developmen
 
 ## Building Images
 
+Before running any build commands, ensure a `base_iso/` directory is present to
+hold the original distribution ISOs. You can create this folder manually with
+`mkdir -p base_iso` or run a script that prepares it for you.
+
 ```bash
 # Build a single image
 ./build.sh base_iso/kali-linux-rolling.iso pentest-kit.img


### PR DESCRIPTION
## Summary
- ensure workflow creates `base_iso` folder before downloading ISOs
- document the `base_iso/` requirement in README

## Testing
- `bash -n build.sh`
- `yamllint .github/workflows/build.yml` *(fails: line-length, indentation, etc.)*

------
https://chatgpt.com/codex/tasks/task_e_687efaa91a1c833099cdb10f015cd045